### PR TITLE
Add account deletion service methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pretendonetwork/grpc",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "AGPL-3.0-only",
   "scripts": {
     "breaking:gh_actions": "buf breaking --against=.git#ref=master --error-format=github-actions=main",

--- a/protobufs/account/v2/account_service.proto
+++ b/protobufs/account/v2/account_service.proto
@@ -7,6 +7,7 @@ import "account/v2/get_nex_data_rpc.proto";
 import "account/v2/get_nex_password_rpc.proto";
 import "account/v2/get_user_data_rpc.proto";
 import "account/v2/update_pnid_permissions.proto";
+import "account/v2/delete_account_rpc.proto";
 
 service AccountService {
   rpc GetUserData(GetUserDataRequest) returns (GetUserDataResponse) {}
@@ -14,4 +15,5 @@ service AccountService {
   rpc GetNEXData(GetNEXDataRequest) returns (GetNEXDataResponse) {}
   rpc UpdatePNIDPermissions(UpdatePNIDPermissionsRequest) returns (UpdatePNIDPermissionsResponse) {}
   rpc ExchangeTokenForUserData(ExchangeTokenForUserDataRequest) returns (ExchangeTokenForUserDataResponse) {}
+  rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse) {}
 }

--- a/protobufs/account/v2/delete_account_rpc.proto
+++ b/protobufs/account/v2/delete_account_rpc.proto
@@ -6,4 +6,6 @@ message DeleteAccountRequest {
   uint32 pid = 1;
 }
 
-message DeleteAccountResponse {}
+message DeleteAccountResponse {
+  bool has_deleted = 1;
+}

--- a/protobufs/account/v2/delete_account_rpc.proto
+++ b/protobufs/account/v2/delete_account_rpc.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package account.v2;
+
+message DeleteAccountRequest {
+  uint32 pid = 1;
+}
+
+message DeleteAccountResponse {}

--- a/protobufs/api/v2/api_service.proto
+++ b/protobufs/api/v2/api_service.proto
@@ -10,6 +10,7 @@ import "api/v2/reset_password_rpc.proto";
 import "api/v2/set_discord_connection_data_rpc.proto";
 import "api/v2/set_stripe_connection_data_rpc.proto";
 import "api/v2/update_user_data_rpc.proto";
+import "api/v2/delete_account_rpc.proto";
 
 service ApiService {
   rpc Register(RegisterRequest) returns (RegisterResponse) {}
@@ -20,4 +21,5 @@ service ApiService {
   rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse) {}
   rpc SetDiscordConnectionData(SetDiscordConnectionDataRequest) returns (SetDiscordConnectionDataResponse) {}
   rpc SetStripeConnectionData(SetStripeConnectionDataRequest) returns (SetStripeConnectionDataResponse) {}
+  rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse) {}
 }

--- a/protobufs/api/v2/delete_account_rpc.proto
+++ b/protobufs/api/v2/delete_account_rpc.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package api.v2;
+
+message DeleteAccountRequest {}
+
+message DeleteAccountResponse {}

--- a/protobufs/api/v2/delete_account_rpc.proto
+++ b/protobufs/api/v2/delete_account_rpc.proto
@@ -2,6 +2,10 @@ syntax = "proto3";
 
 package api.v2;
 
-message DeleteAccountRequest {}
+message DeleteAccountRequest {
+  uint32 pid = 1;
+}
 
-message DeleteAccountResponse {}
+message DeleteAccountResponse {
+  bool has_deleted = 1;
+}

--- a/protobufs/miiverse/v2/delete_account_data_rpc.proto
+++ b/protobufs/miiverse/v2/delete_account_data_rpc.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package miiverse.v2;
+
+message DeleteAccountDataRequest {
+  uint32 pid = 1;
+}
+
+message DeleteAccountDataResponse {}

--- a/protobufs/miiverse/v2/delete_account_data_rpc.proto
+++ b/protobufs/miiverse/v2/delete_account_data_rpc.proto
@@ -6,4 +6,7 @@ message DeleteAccountDataRequest {
   uint32 pid = 1;
 }
 
-message DeleteAccountDataResponse {}
+message DeleteAccountDataResponse {
+  bool has_deleted = 1;
+  uint32 posts_deleted = 2;
+}

--- a/protobufs/miiverse/v2/miiverse_service.proto
+++ b/protobufs/miiverse/v2/miiverse_service.proto
@@ -3,8 +3,11 @@ syntax = "proto3";
 package miiverse.v2;
 
 import "miiverse/v2/smm_request_post_id_rpc.proto";
+import "miiverse/v2/delete_account_data_rpc.proto";
 
 service MiiverseService {
+  rpc DeleteAccountData(DeleteAccountDataRequest) returns (DeleteAccountDataResponse) {}
+
   // Used by Super Mario Maker
   rpc SMMRequestPostId(SMMRequestPostIdRequest) returns (SMMRequestPostIdResponse) {}
 }


### PR DESCRIPTION
This is to introduce self-service and admin panel account deletions. I've been doing all this manually for too long now.

Changes:
- Added `DeleteAccount({ pid })` to `api.v2`. This is for website users to delete their account with a simple button.
- Added `DeleteAccount({ pid })` to `account.v2`. This is for admin panel users to delete someone's account.
- Added `DeleteAccountData({ pid })` to `miiverse.v2`. This is for the account service to delete Juxt account data.

As for implementation. Account service will do the following when an account deletion is requested (same for all methods: website, console and admin panel).
- Call Juxt GRPC method to delete all the account data
- Call Stripe API to delete customer data, if applicable
- Call Discourse API to anonymize account data
- Purge the PNID data using the existing method

Stripe and discourse credentials will be made optional in the account service config.

