### PR TITLE
Update `ExchangeIndependentServiceTokenForUserDataRequest` and `ExchangeNEXTokenForUserDataRequest` APIs

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -50,3 +50,5 @@ lint:
 breaking:
   use:
     - FILE
+  ignore:
+    - protobufs/account/v2 # Temp, remove after https://github.com/PretendoNetwork/grpc/pull/15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pretendonetwork/grpc",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/protobufs/account/v2/basic_user_info.proto
+++ b/protobufs/account/v2/basic_user_info.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package account.v2;
+
+import "account/v2/ban_details.proto";
+
+message BasicUserInfo {
+  bool access_beta_servers = 1;
+  bool access_developer_servers = 2;
+  optional Ban ban = 3; // * Not present if not banned
+}

--- a/protobufs/account/v2/exchange_independent_service_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_independent_service_token_for_user_data_rpc.proto
@@ -6,18 +6,9 @@ import "account/v2/get_pnid_rpc.proto";
 import "account/v2/nex_account.proto";
 import "account/v2/token_info.proto";
 
-// TODO - Move this to own file
-enum IndependentServiceTokenProviderType {
-  INDEPENDENT_SERVICE_TOKEN_PROVIDER_TYPE_UNSPECIFIED = 0;
-  INDEPENDENT_SERVICE_TOKEN_PROVIDER_TYPE_NASC = 1;
-  INDEPENDENT_SERVICE_TOKEN_PROVIDER_TYPE_NNAS = 2;
-}
-
 message ExchangeIndependentServiceTokenForUserDataRequest {
-  IndependentServiceTokenProviderType provider = 1;
-  optional string client_id = 2; // * For NNAS
-  repeated string title_ids = 3; // * For NASC
-  string token = 4;
+  repeated string client_ids = 1;
+  string token = 2;
 }
 
 message ExchangeIndependentServiceTokenForUserDataResponse {

--- a/protobufs/account/v2/exchange_independent_service_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_independent_service_token_for_user_data_rpc.proto
@@ -5,6 +5,7 @@ package account.v2;
 import "account/v2/get_pnid_rpc.proto";
 import "account/v2/nex_account.proto";
 import "account/v2/token_info.proto";
+import "account/v2/basic_user_info.proto";
 
 message ExchangeIndependentServiceTokenForUserDataRequest {
   repeated string client_ids = 1;
@@ -15,4 +16,5 @@ message ExchangeIndependentServiceTokenForUserDataResponse {
   optional GetPNIDResponse pnid = 1; // * May not be present when using a NASC token
   NEXAccount nex_account = 2;
   TokenInfo token_info = 3;
+  BasicUserInfo basic_user_info = 4;
 }

--- a/protobufs/account/v2/exchange_nex_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_nex_token_for_user_data_rpc.proto
@@ -4,6 +4,7 @@ package account.v2;
 
 import "account/v2/nex_account.proto";
 import "account/v2/token_info.proto";
+import "account/v2/basic_user_info.proto";
 
 message ExchangeNEXTokenForUserDataRequest {
   repeated string game_server_ids = 1;
@@ -12,5 +13,6 @@ message ExchangeNEXTokenForUserDataRequest {
 
 message ExchangeNEXTokenForUserDataResponse {
   NEXAccount nex_account = 1;
-  TokenInfo token_info = 3;
+  TokenInfo token_info = 2;
+  BasicUserInfo basic_user_info = 3;
 }

--- a/protobufs/account/v2/exchange_nex_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_nex_token_for_user_data_rpc.proto
@@ -6,7 +6,7 @@ import "account/v2/nex_account.proto";
 import "account/v2/token_info.proto";
 
 message ExchangeNEXTokenForUserDataRequest {
-  string game_server_id = 1;
+  repeated string game_server_ids = 1;
   string token = 2;
 }
 

--- a/protobufs/account/v2/exchange_oauth_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_oauth_token_for_user_data_rpc.proto
@@ -5,6 +5,7 @@ package account.v2;
 import "account/v2/get_pnid_rpc.proto";
 import "account/v2/nex_account.proto";
 import "account/v2/token_info.proto";
+import "account/v2/basic_user_info.proto";
 
 message ExchangeOAuthTokenForUserDataRequest {
   string client_id = 1;
@@ -16,4 +17,5 @@ message ExchangeOAuthTokenForUserDataResponse {
   GetPNIDResponse pnid = 1;
   NEXAccount nex_account = 2;
   TokenInfo token_info = 3;
+  BasicUserInfo basic_user_info = 4;
 }

--- a/protobufs/account/v2/exchange_password_reset_token_for_user_data_rpc.proto
+++ b/protobufs/account/v2/exchange_password_reset_token_for_user_data_rpc.proto
@@ -4,6 +4,7 @@ package account.v2;
 
 import "account/v2/get_pnid_rpc.proto";
 import "account/v2/token_info.proto";
+import "account/v2/basic_user_info.proto";
 
 message ExchangePasswordResetTokenForUserDataRequest {
   string token = 1;
@@ -11,5 +12,6 @@ message ExchangePasswordResetTokenForUserDataRequest {
 
 message ExchangePasswordResetTokenForUserDataResponse {
   GetPNIDResponse pnid = 1;
-  TokenInfo token_info = 3;
+  TokenInfo token_info = 2;
+  BasicUserInfo basic_user_info = 3;
 }

--- a/protobufs/account/v2/validate_independent_service_token_rpc.proto
+++ b/protobufs/account/v2/validate_independent_service_token_rpc.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package account.v2;
 
-import "account/v2/ban_details.proto";
+import "account/v2/basic_user_info.proto";
 
 message ValidateIndependentServiceTokenRequest {
   repeated string client_ids = 1;
@@ -10,12 +10,6 @@ message ValidateIndependentServiceTokenRequest {
 }
 
 message ValidateIndependentServiceTokenResponse {
-  message UserInfo {
-    bool access_beta_servers = 1;
-    bool access_developer_servers = 2;
-    optional Ban ban = 3; // * Not present if not banned
-  }
-
   bool is_valid = 1;
-  optional UserInfo user_info = 2; // * Not present if is_valid is false
+  optional BasicUserInfo basic_user_info = 2; // * Not present if is_valid is false
 }

--- a/protobufs/account/v2/validate_independent_service_token_rpc.proto
+++ b/protobufs/account/v2/validate_independent_service_token_rpc.proto
@@ -3,13 +3,10 @@ syntax = "proto3";
 package account.v2;
 
 import "account/v2/ban_details.proto";
-import "account/v2/exchange_independent_service_token_for_user_data_rpc.proto";
 
 message ValidateIndependentServiceTokenRequest {
-  IndependentServiceTokenProviderType provider = 1;
-  optional string client_id = 2; // * For NNAS
-  repeated string title_ids = 3; // * For NASC
-  string token = 4;
+  repeated string client_ids = 1;
+  string token = 2;
 }
 
 message ValidateIndependentServiceTokenResponse {


### PR DESCRIPTION
Resolves #XXX

### Changes:

After implementing the changes made in https://github.com/PretendoNetwork/grpc/pull/10 when actually implementing the new API, there were a few pain points that were missed. Namely:

- The `provider` field in `ExchangeIndependentServiceTokenForUserDataRequest` was useless, since the common protocols don't know what provider is being used when only the token is present, and the field was being ignored by the account server as just extra fluff
- `ExchangeIndependentServiceTokenForUserDataRequest` made it awkward to define multiple servers as valid for a token. For example, our Pokemon servers are shared between multiple games which have different title IDs/game server IDs/key hashes. To support these cases, `client_id` was made optional and the caller was expected to provide a list of acceptable title IDs in it's place. However this was awkward and there can be tons of title IDs (like how we recently got told of a Korean title ID for MK7 that we didn't support)
- `ExchangeNEXTokenForUserDataRequest` had no way to define multiple acceptable servers, resulting in issues for the common protocols. See https://github.com/PretendoNetwork/nex-protocols-common-go/pull/61 for details

This aims to address these issues by simplifying the APIs and providing a cleaner way to define multiple targets. The tokens PR for the account server (https://github.com/PretendoNetwork/account/pull/313) defines a `client_id`/`game_server_id` to all tokens anyway (even NASC NEX tokens, using the `keyhash`) so it's already being accounted for

Version number not bumped yet, pending approval

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.